### PR TITLE
Circleci config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  ruby:
+    version: 2.1.5

--- a/circle.yml
+++ b/circle.yml
@@ -2,5 +2,6 @@ machine:
   ruby:
     version: 2.1.5
 dependencies:
-  pre:
-    - gem install bundler --pre
+  override:
+    - gem install bundler -v 1.7
+    - bundle install

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,10 @@
 machine:
   ruby:
     version: 2.1.5
+  environment:
+    API_ROOT: https://v4.hydraengine.com
 dependencies:
   override:
     - gem install bundler -v 1.7
     - bundle install
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
 machine:
   ruby:
     version: 2.1.5
+dependencies:
+  pre:
+    - gem install bundler --pre


### PR DESCRIPTION
It almost^tm works.

Installs ruby and bundler dependencies, starts testing with rake and fails there:

```
bundle exec rspec --color --order random spec --format progress
.FF

Failures:

  1) Syncano::Connection#authenticate successful should get an API key
     Failure/Error: let(:authenticate_uri) { Syncano::Connection.api_root + "/v1/account/auth/" }
     NoMethodError:
       undefined method `+' for nil:NilClass
     # ./spec/unit/connection_spec.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/unit/connection_spec.rb:23:in `block (4 levels) in <top (required)>'

  2) Syncano::Connection#authenticate failed should raise an exception
     Failure/Error: let(:authenticate_uri) { Syncano::Connection.api_root + "/v1/account/auth/" }
     NoMethodError:
       undefined method `+' for nil:NilClass
     # ./spec/unit/connection_spec.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/unit/connection_spec.rb:43:in `block (4 levels) in <top (required)>'

Finished in 0.00285 seconds (files took 0.31747 seconds to load)
3 examples, 2 failures

Failed examples:

rspec ./spec/unit/connection_spec.rb:28 # Syncano::Connection#authenticate successful should get an API key
rspec ./spec/unit/connection_spec.rb:49 # Syncano::Connection#authenticate failed should raise an exception

Randomized with seed 2385 ((bundle exec rspec "--color --order random" "" "spec" --format "progress")) returned exit code 1
```

Does it miss something or is it the expected behavior?
